### PR TITLE
Fixed compile issue for archlinux

### DIFF
--- a/RetroChess.pro
+++ b/RetroChess.pro
@@ -22,7 +22,7 @@ INCLUDEPATH += ../../rapidjson-1.1.0
 #################################### Windows #####################################
 
 linux-* {
-	INCLUDEPATH += /usr/include
+	#INCLUDEPATH += /usr/include
 	#LIBS += $$system(pkg-config --libs opencv)
 }
 


### PR DESCRIPTION
Remove `INCLUDEPATH += /usr/include` to solve compile issue (on Archlinux)